### PR TITLE
other widgets can be an emitter

### DIFF
--- a/examples/using_other_widget_as_an_emitter.py
+++ b/examples/using_other_widget_as_an_emitter.py
@@ -1,0 +1,99 @@
+from kivy.properties import ObjectProperty
+from kivy.app import runTouchApp
+from kivy.lang import Builder
+from kivy.uix.label import Label
+from kivy.uix.floatlayout import FloatLayout
+
+from kivy_garden.draggable import KXDroppableBehavior, KXDraggableBehavior
+
+KV_CODE = '''
+#:import ascii_uppercase string.ascii_uppercase
+
+<Cell>:
+    drag_classes: ['card', ]
+    canvas.before:
+        Color:
+            rgba: .1, .1, .1, 1
+        Rectangle:
+            pos: self.pos
+            size: self.size
+<Card>:
+    drag_cls: 'card'
+    drag_timeout: 0
+    font_size: 100
+    opacity: .3 if self.is_being_dragged else 1.
+    canvas.after:
+        Color:
+            rgba: 1, 1, 1, 1
+        Line:
+            rectangle: [*self.pos, *self.size, ]
+<Deck>:
+    canvas.after:
+        Color:
+            rgba: 1, 1, 1, 1
+        Line:
+            rectangle: [*self.pos, *self.size, ]
+
+BoxLayout:
+    Widget:
+        size_hint_x: .1
+
+    # use RelativeLayout just to make sure the coordinates are properly
+    # transformed.
+    RelativeLayout:
+        GridLayout:
+            id: board
+            cols: 4
+            rows: 4
+            spacing: 10
+            padding: 10
+
+    BoxLayout:
+        orientation: 'vertical'
+        size_hint_x: .2
+        padding: '20dp', '40dp'
+        spacing: '80dp'
+        RelativeLayout:  # use RelativeLayout just ...
+            Deck:
+                text: 'numbers'
+                font_size: '20sp'
+                text_iter: (str(i) for i in range(10))
+        Deck:
+            text: 'letters'
+            font_size: '20sp'
+            text_iter: iter(ascii_uppercase)
+'''
+
+
+class Cell(KXDroppableBehavior, FloatLayout):
+    def accepts_drag(self, touch, draggable) -> bool:
+        return not self.children
+
+    def add_widget(self, widget, *args, **kwargs):
+        widget.size_hint = (1, 1, )
+        widget.pos_hint = {'x': 0, 'y': 0, }
+        return super().add_widget(widget, *args, **kwargs)
+
+
+class Card(KXDraggableBehavior, Label):
+    pass
+
+
+class Deck(Label):
+    text_iter = ObjectProperty()
+
+    def on_touch_down(self, touch):
+        if self.collide_point(*touch.opos):
+            try:
+                Card(text=next(self.text_iter)) \
+                    .drag_start_from_other_widget(self, touch)
+            except StopIteration:
+                pass
+            return True
+
+
+root = Builder.load_string(KV_CODE)
+board = root.ids.board
+for __ in range(board.cols * board.rows):
+    board.add_widget(Cell())
+runTouchApp(root)


### PR DESCRIPTION
Sometimes the users want a draggable and the widget who triggers the drag to be different. This PR implements that.

```python
class Draggable(KXDraggableBehavior, Widget):
    pass


class Emitter(Widget):
    def on_touch_down(self, touch):
        if self.collide_point(*touch.opos):
            Draggable().drag_start_from_other_widget(self, touch)
            return True
        return super().on_touch_down(touch)
```

[Youtube](https://youtu.be/31V563AdVpU)

### for those who's curious to this PR

I don't think `drag_start_from_other_widget()` is a good name, but I didn't come up with any betters ones. **Could you suggest me better one?** (Since there is `drag_cancel()` method, I feel like the method's name needs to start with `drag_start`). Also, one of the parameters is named `emitter`, **Do you think it's a good name?**.