### PR TITLE
refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ class KXDraggableBehavior:
     async def on_drag_fail(self, touch):
         ctx = self.drag_context
         await ak.animate(
-            self, d=.1,
+            self, duration=.1,
             x=ctx.original_pos_win[0],
             y=ctx.original_pos_win[1],
         )

--- a/examples/cancelling_ongoing_drags.py
+++ b/examples/cancelling_ongoing_drags.py
@@ -6,15 +6,14 @@ from kivy.app import App
 from kivy.lang import Builder
 from kivy.factory import Factory
 
-from kivy_garden.draggable import (
-    KXDraggableBehavior, restore_widget_location, ongoing_drags,
-)
+from kivy_garden.draggable import ongoing_drags
 
 
 KV_CODE = '''
 #:import create_spacer kivy_garden.draggable._utils._create_spacer
 
 <ReorderableGridLayout@KXReorderableBehavior+GridLayout>:
+
 <DraggableItem@KXDraggableBehavior+Label>:
     drag_cls: 'test'
     drag_timeout: 50
@@ -28,6 +27,7 @@ KV_CODE = '''
         Line:
             width: 2 if root.is_being_dragged else 1
             rectangle: [*self.pos, *self.size, ]
+
 <MyButton@Button>:
     font_size: sp(20)
     size_hint_min_x: self.texture_size[0] + dp(10)
@@ -42,9 +42,7 @@ BoxLayout:
         spacing: 10
         drag_classes: ['test', ]
         cols: 6
-        spacer_widgets:
-            [create_spacer(color=color)
-            for color in "#000044 #002200 #440000".split()]
+        spacer_widgets: [create_spacer(color=color) for color in "#000044 #002200 #440000".split()]
     BoxLayout:
         spacing: 10
         orientation: 'vertical'

--- a/examples/combining_draggable_with_magnet.py
+++ b/examples/combining_draggable_with_magnet.py
@@ -2,9 +2,7 @@ from kivy.app import App
 from kivy.lang import Builder
 from kivy.factory import Factory
 from kivy.clock import Clock
-from kivy.properties import (
-    NumericProperty, StringProperty, BooleanProperty,
-)
+from kivy.properties import NumericProperty, StringProperty, BooleanProperty
 import asynckivy as ak
 
 import kivy_garden.draggable
@@ -19,10 +17,8 @@ class Magnet(Factory.Widget):
     anim_duration = NumericProperty(1)
     anim_transition = StringProperty('out_quad')
 
-    # default value of the instance attributes
-    _coro = ak.sleep_forever()
-
     def __init__(self, **kwargs):
+        self._task = ak.dummy_task
         self._anim_trigger = trigger = Clock.create_trigger(self._start_anim, -1)
         super().__init__(**kwargs)
         self.fbind('pos', trigger)
@@ -38,12 +34,12 @@ class Magnet(Factory.Widget):
     def _start_anim(self, *args):
         if self.children:
             child = self.children[0]
-            self._coro.close()
+            self._task.cancel()
             if not self.do_anim:
                 child.pos = self.pos
                 child.size = self.size
                 return
-            self._coro = ak.start(ak.animate(
+            self._task = ak.start(ak.animate(
                 child,
                 d=self.anim_duration,
                 t=self.anim_transition,
@@ -55,6 +51,7 @@ KV_CODE = '''
 #:import create_spacer kivy_garden.draggable._utils._create_spacer
 
 <ReorderableGridLayout@KXReorderableBehavior+GridLayout>:
+
 <DraggableItem@KXDraggableBehavior+Magnet>:
     do_anim: not self.is_being_dragged
     anim_duration: .2

--- a/examples/combining_draggable_with_magnet.py
+++ b/examples/combining_draggable_with_magnet.py
@@ -41,8 +41,8 @@ class Magnet(Factory.Widget):
                 return
             self._task = ak.start(ak.animate(
                 child,
-                d=self.anim_duration,
-                t=self.anim_transition,
+                duration=self.anim_duration,
+                transition=self.anim_transition,
                 x=self.x, y=self.y, width=self.width, height=self.height,
             ))
 

--- a/examples/customizing_animation.py
+++ b/examples/customizing_animation.py
@@ -57,7 +57,7 @@ class MyDraggable(KXDraggableBehavior, Label):
     _scale = NumericProperty(1.)
 
     async def on_drag_fail(self, touch):
-        await ak.animate(self, d=.4, _angle=720, opacity=0)
+        await ak.animate(self, _angle=720, opacity=0, duration=.4)
         self.parent.remove_widget(self)
 
     async def on_drag_success(self, touch):

--- a/examples/customizing_animation.py
+++ b/examples/customizing_animation.py
@@ -3,12 +3,13 @@
 '''
 
 
-from kivy.app import runTouchApp
+from kivy.app import App
 from kivy.lang import Builder
 from kivy.properties import NumericProperty
 from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.label import Label
 import asynckivy as ak
+from asynckivy import vanim
 
 from kivy_garden.draggable import KXDroppableBehavior, KXDraggableBehavior
 
@@ -63,8 +64,9 @@ class MyDraggable(KXDraggableBehavior, Label):
         ctx = self.drag_context
         self.parent.remove_widget(self)
         ctx.droppable.add_widget(self)
-        await ak.animate(self, d=.1, _scale=.6)
-        await ak.animate(self, d=.1, _scale=1)
+        abs_ = abs
+        async for p in vanim.progress(duration=.2):
+            self._scale = abs_(p * .8 - .4) + .6
 
 
 class Cell(KXDroppableBehavior, FloatLayout):
@@ -77,12 +79,18 @@ class Cell(KXDroppableBehavior, FloatLayout):
         return super().add_widget(widget, *args, **kwargs)
 
 
-root = Builder.load_string(KV_CODE)
-board = root
-for __ in range(board.cols * board.rows):
-    board.add_widget(Cell())
-cells = board.children
-for cell, i in zip(cells, range(4)):
-    cell.add_widget(MyDraggable(text=str(i)))
+class SampleApp(App):
+    def build(self):
+        return Builder.load_string(KV_CODE)
 
-runTouchApp(root)
+    def on_start(self):
+        board = self.root
+        for __ in range(board.cols * board.rows):
+            board.add_widget(Cell())
+        cells = board.children
+        for cell, i in zip(cells, range(4)):
+            cell.add_widget(MyDraggable(text=str(i)))
+
+
+if __name__ == '__main__':
+    SampleApp().run()

--- a/examples/draggable_can_work_with_scrollview.py
+++ b/examples/draggable_can_work_with_scrollview.py
@@ -2,7 +2,7 @@
 Nothing special. Just an example of re-orderable BoxLayout.
 '''
 
-from kivy.app import runTouchApp
+from kivy.app import App
 from kivy.lang import Builder
 from kivy.factory import Factory
 import kivy_garden.draggable
@@ -20,6 +20,7 @@ KV_CODE = '''
         Line:
             width: 2
             rectangle: [*self.pos, *self.size, ]
+
 <ReorderableBoxLayout@KXReorderableBehavior+BoxLayout>:
 
 ScrollView:
@@ -38,11 +39,17 @@ ScrollView:
         size_hint_min_y: self.minimum_height
 '''
 
-root = Builder.load_string(KV_CODE)
-DraggableItem = Factory.DraggableItem
-boxlayout = root.ids.boxlayout.__self__
-add_widget = boxlayout.add_widget
-for i in range(100):
-    add_widget(DraggableItem(text=str(i)))
 
-runTouchApp(root)
+class SampleApp(App):
+    def build(self):
+        return Builder.load_string(KV_CODE)
+
+    def on_start(self):
+        DraggableItem = Factory.DraggableItem
+        add_widget = self.root.ids.boxlayout.add_widget
+        for i in range(100):
+            add_widget(DraggableItem(text=str(i)))
+
+
+if __name__ == '__main__':
+    SampleApp().run()

--- a/examples/flutter_style_draggable.py
+++ b/examples/flutter_style_draggable.py
@@ -4,14 +4,12 @@ This example shows how to achive the same functionality as Flutter one's
 https://api.flutter.dev/flutter/widgets/Draggable-class.html
 '''
 
-from kivy.app import runTouchApp
+from kivy.app import App
 from kivy.lang import Builder
 from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.screenmanager import ScreenManager, NoTransition
 
-from kivy_garden.draggable import (
-    KXDroppableBehavior, KXDraggableBehavior, restore_widget_location,
-)
+from kivy_garden.draggable import KXDroppableBehavior, KXDraggableBehavior, restore_widget_location
 
 KV_CODE = '''
 <Cell>:
@@ -97,12 +95,18 @@ class Cell(KXDroppableBehavior, FloatLayout):
         return super().add_widget(widget, *args, **kwargs)
 
 
-root = Builder.load_string(KV_CODE)
-board = root
-for __ in range(board.cols * board.rows):
-    board.add_widget(Cell())
-cells = board.children
-for cell, __ in zip(cells, range(4)):
-    cell.add_widget(FlutterStyleDraggable())
+class SampleApp(App):
+    def build(self):
+        return Builder.load_string(KV_CODE)
 
-runTouchApp(root)
+    def on_start(self):
+        board = self.root
+        for __ in range(board.cols * board.rows):
+            board.add_widget(Cell())
+        cells = board.children
+        for cell, __ in zip(cells, range(4)):
+            cell.add_widget(FlutterStyleDraggable())
+
+
+if __name__ == '__main__':
+    SampleApp().run()

--- a/examples/reacting_to_entering_and_leaving.py
+++ b/examples/reacting_to_entering_and_leaving.py
@@ -1,13 +1,11 @@
+from kivy.utils import reify
 from kivy.properties import NumericProperty
 from kivy.app import App
 from kivy.lang import Builder
-from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.label import Label
 import asynckivy as ak
 
-from kivy_garden.draggable import (
-    KXDraggableBehavior, KXDroppableBehavior,
-)
+from kivy_garden.draggable import KXDraggableBehavior, KXDroppableBehavior
 
 KV_CODE = '''
 <MyDroppable>:
@@ -39,7 +37,6 @@ KV_CODE = '''
 <VDivider@Divider>:
     size_hint_x: None
     width: 1
-
 
 BoxLayout:
     orientation: 'vertical'
@@ -98,9 +95,9 @@ class ReactiveDroppableBehavior(KXDroppableBehavior):
     '''
     __events__ = ('on_drag_enter', 'on_drag_leave', )
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.__ud_key = 'ReactiveDroppableBehavior.' + str(self.uid)
+    @reify
+    def __ud_key(self):
+        return 'ReactiveDroppableBehavior.' + str(self.uid)
 
     def on_touch_move(self, touch):
         ud_key = self.__ud_key
@@ -110,12 +107,11 @@ class ReactiveDroppableBehavior(KXDroppableBehavior):
             if drag_cls is not None:
                 touch_ud[ud_key] = None
                 if drag_cls in self.drag_classes:
-                    # Watches 'is_being_dragged' as well, so that the
-                    # '_watch_touch()' will be automatically cancelled when
-                    # the drag is cancelled.
+                    # Start watching the touch. Use ``ak.or_()`` so that ``_watch_touch()`` will be automatically
+                    # cancelled when the drag is cancelled.
                     ak.start(ak.or_(
                         self._watch_touch(touch),
-                        ak.event(touch.ud['kivyx_draggable'], 'is_being_dragged'),
+                        ak.event(touch.ud['kivyx_draggable'], 'on_drag_end'),
                     ))
         return super().on_touch_move(touch)
 

--- a/examples/reorderable_stacklayout.py
+++ b/examples/reorderable_stacklayout.py
@@ -2,12 +2,12 @@
 When you want to make ``StackLayout`` re-orderable, you may want to disable
 the ``size_hint`` of each child, or may want to limit the maximum size of
 each child, otherwise the layout may be messed up. You can confirm it by
-commenting/uncommenting the last part of this file.
+commenting/uncommenting the ``SampleApp.on_start()``'s body.
 '''
 
 from kivy.lang import Builder
 from kivy.factory import Factory
-from kivy.app import runTouchApp
+from kivy.app import App
 import kivy_garden.draggable
 
 
@@ -42,20 +42,27 @@ def random_size():
     return (uniform(50.0, 150.0), uniform(50.0, 150.0), )
 
 
-root = Builder.load_string(KV_CODE)
-Item = Factory.MyDraggableItem
-Item()
-add_widget = root.ids.layout.add_widget
-for i in range(30):
-    # A (works)
-    add_widget(Item(text=str(i), size=random_size(), size_hint=(None, None)))
+class SampleApp(App):
+    def build(self):
+        return Builder.load_string(KV_CODE)
 
-    # B (works)
-    # add_widget(Item(text=str(i), size_hint_max=random_size()))
+    def on_start(self):
+        Item = Factory.MyDraggableItem
+        Item()
+        add_widget = self.root.ids.layout.add_widget
+        for i in range(30):
+            # A (works)
+            add_widget(Item(text=str(i), size=random_size(), size_hint=(None, None)))
 
-    # C (does not work)
-    # add_widget(Item(text=str(i), size_hint_min=random_size()))
+            # B (works)
+            # add_widget(Item(text=str(i), size_hint_max=random_size()))
 
-    # D (does not work)
-    # add_widget(Item(text=str(i)))
-runTouchApp(root)
+            # C (does not work)
+            # add_widget(Item(text=str(i), size_hint_min=random_size()))
+
+            # D (does not work)
+            # add_widget(Item(text=str(i)))
+
+
+if __name__ == '__main__':
+    SampleApp().run()

--- a/examples/shopping.py
+++ b/examples/shopping.py
@@ -20,6 +20,7 @@ from kivy_garden.draggable import KXDraggableBehavior
 KV_CODE = r'''
 <SHLabel@Label,SHButton@Button>:
     size_hint_min: [v + dp(8) for v in self.texture_size]
+
 <SHFood>:
     orientation: 'vertical'
     spacing: '4dp'
@@ -39,12 +40,14 @@ KV_CODE = r'''
         size_hint_y: 3.
     SHLabel:
         text: '{} ({} yen)'.format(root.datum.name, root.datum.price)
+
 <SHShelf@KXReorderableBehavior+RVLikeBehavior+StackLayout>:
     padding: '10dp'
     spacing: '10dp'
     size_hint_min_y: self.minimum_height
     drag_classes: ['food', ]
     viewclass: 'SHFood'
+
 <SHMain>:
     orientation: 'vertical'
     padding: '10dp'
@@ -111,6 +114,7 @@ class ShoppingApp(App):
     def build(self):
         Builder.load_string(KV_CODE)
         return SHMain()
+
     def on_start(self):
         ak.start(self.root.main(db_path=__file__ + r".sqlite3"))
 
@@ -193,7 +197,7 @@ class SHMain(F.BoxLayout):
 
             # download images
             with ThreadPoolExecutor() as executer:
-                with requests.Session() as session:  # The Session object may not be thread-safe so it's probably better not to share it between threads...
+                with requests.Session() as session:  # TODO: The Session object may not be thread-safe so it's probably better not to share it between threads...
                     async def download_one_image(name, image_url) -> Tuple[bytes, str]:
                         image = await ak.run_in_executer(lambda: session.get(image_url).content, executer)
                         return (image, name)

--- a/examples/using_other_widget_as_an_emitter.py
+++ b/examples/using_other_widget_as_an_emitter.py
@@ -1,5 +1,5 @@
 from kivy.properties import ObjectProperty
-from kivy.app import runTouchApp
+from kivy.app import App
 from kivy.lang import Builder
 from kivy.uix.label import Label
 from kivy.uix.floatlayout import FloatLayout
@@ -38,7 +38,8 @@ BoxLayout:
     Widget:
         size_hint_x: .1
 
-    # use RelativeLayout just to confirm the coordinates are properly transformed.
+    # Put the board inside a RelativeLayout just to confirm the coordinates are properly transformed.
+    # It's not necessary for this example to work.
     RelativeLayout:
         GridLayout:
             id: board
@@ -52,7 +53,7 @@ BoxLayout:
         size_hint_x: .2
         padding: '20dp', '40dp'
         spacing: '80dp'
-        RelativeLayout:  # use RelativeLayout just ...
+        RelativeLayout:  # Put a deck inside a RelativeLayout just ...
             Deck:
                 board: board
                 text: 'numbers'
@@ -86,16 +87,21 @@ class Deck(Label):
 
     def on_touch_down(self, touch):
         if self.collide_point(*touch.opos):
-            try:
-                card = Card(text=next(self.text_iter), size=self.board.children[0].size)
+            if (text := next(self.text_iter, None)) is not None:
+                card = Card(text=text, size=self.board.children[0].size)
                 card.drag_start_from_others_touch(self, touch)
-            except StopIteration:
-                pass
             return True
 
 
-root = Builder.load_string(KV_CODE)
-board = root.ids.board
-for __ in range(board.cols * board.rows):
-    board.add_widget(Cell())
-runTouchApp(root)
+class SampleApp(App):
+    def build(self):
+        return Builder.load_string(KV_CODE)
+
+    def on_start(self):
+        board = self.root.ids.board
+        for __ in range(board.cols * board.rows):
+            board.add_widget(Cell())
+
+
+if __name__ == '__main__':
+    SampleApp().run()

--- a/kivy_garden/draggable/_impl.py
+++ b/kivy_garden/draggable/_impl.py
@@ -281,7 +281,7 @@ class KXDraggableBehavior:
     async def on_drag_fail(self, touch):
         ctx = self._drag_ctx
         await ak.animate(
-            self, d=.1,
+            self, duration=.1,
             x=ctx.original_pos_win[0],
             y=ctx.original_pos_win[1],
         )

--- a/kivy_garden/draggable/_impl.py
+++ b/kivy_garden/draggable/_impl.py
@@ -379,12 +379,11 @@ class KXReorderableBehavior:
             if drag_cls is not None:
                 touch_ud[ud_key] = None
                 if drag_cls in self.drag_classes:
-                    # Watches 'is_being_dragged' as well, so that the
-                    # '_watch_touch()' will be automatically cancelled when
-                    # the drag is cancelled.
+                    # Start watching the touch. Use ``ak.or_()`` so that ``_watch_touch()`` will be automatically
+                    # cancelled when the drag is cancelled.
                     ak.start(ak.or_(
                         self._watch_touch(touch),
-                        ak.event(touch.ud['kivyx_draggable'], 'is_being_dragged'),
+                        ak.event(touch.ud['kivyx_draggable'], 'on_drag_end'),
                     ))
         return super().on_touch_move(touch)
 

--- a/kivy_garden/draggable/_utils.py
+++ b/kivy_garden/draggable/_utils.py
@@ -4,26 +4,34 @@ __all__ = (
 )
 
 from weakref import ref
-from contextlib import contextmanager
 from copy import deepcopy
 
 
-@contextmanager
-def temp_transform(touch):
-    touch.push()
-    try:
-        yield
-    finally:
-        touch.pop()
+class temp_transform:
+    __slots__ = ('_touch', )
+
+    def __init__(self, touch):
+        self._touch = touch
+
+    def __enter__(self):
+        self._touch.push()
+
+    def __exit__(self, *args):
+        self._touch.pop()
 
 
-@contextmanager
-def temp_grab_current(touch):
-    original = touch.grab_current
-    try:
-        yield
-    finally:
-        touch.grab_current = original
+class temp_grab_current:
+    __slots__ = ('_touch', '_original', )
+
+    def __init__(self, touch):
+        self._touch = touch
+        self._original = touch.grab_current
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *args):
+        self._touch.grab_current = self._original
 
 
 _shallow_copyable_property_names = (

--- a/kivy_garden/draggable/_utils.py
+++ b/kivy_garden/draggable/_utils.py
@@ -8,13 +8,16 @@ from copy import deepcopy
 
 
 class temp_transform:
-    __slots__ = ('_touch', )
+    __slots__ = ('_touch', '_func')
 
-    def __init__(self, touch):
+    def __init__(self, touch, func):
         self._touch = touch
+        self._func = func
 
     def __enter__(self):
-        self._touch.push()
+        t = self._touch
+        t.push()
+        t.apply_transform_2d(self._func)
 
     def __exit__(self, *args):
         self._touch.pop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,9 @@ python = "^3.7"
 asynckivy = "~0.5"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.4.3"
-flake8 = "^3.8.4"
+pytest = "^7.1.2"
+flake8 = "^5.0.4"
+kivy = {url = "https://github.com/kivy/kivy/archive/refs/tags/2.1.0.zip"}
 
 [build-system]
 requires = ["poetry>=0.12", "setuptools"]


### PR DESCRIPTION
Mainly does the following

- stop using `kivy.app.runTouchApp`
- stop using the following abbreviations
  - duration -> d
  - transition -> t
  - step -> s
- use `kivy.utils.reify` when it makes code cleaner
- use newly added `asynckivy.utils.transform` and `asynckivy.vanim`