### PR TITLE
make the library compatible with asyncio/trio

### DIFF
--- a/examples/combining_draggable_with_magnet_ver_asyncio.py
+++ b/examples/combining_draggable_with_magnet_ver_asyncio.py
@@ -1,0 +1,6 @@
+from combining_draggable_with_magnet import SampleApp
+
+
+if __name__ == '__main__':
+    import asyncio
+    asyncio.run(SampleApp().async_run('asyncio'))

--- a/examples/reacting_to_entering_and_leaving.py
+++ b/examples/reacting_to_entering_and_leaving.py
@@ -121,9 +121,10 @@ class ReactiveDroppableBehavior(KXDroppableBehavior):
 
         self.dispatch('on_drag_enter', touch, draggable)
         try:
-            async for __ in ak.rest_of_touch_moves(self, touch):
-                if not collide_point(*touch.pos):
-                    return
+            async with ak.watch_touch(self, touch) as is_touch_move:
+                while await is_touch_move():
+                    if not collide_point(*touch.pos):
+                        return
         finally:
             self.dispatch('on_drag_leave', touch, draggable)
             del touch.ud[self.__ud_key]


### PR DESCRIPTION
Some of features in `asynckivy` sometimes don't work if Kivy is running in `asyncio`/`trio` mode, which makes this library incompatible with them. You can confirm that by running the newly added example `combining_draggable_with_magnet_ver_asyncio.py` **without** applying the other part of the pull request. The following text is what I get when I run the example and start dragging a widget.

```
 Task exception was never retrieved
 future: <Task finished name='Task-2' coro=<<async_generator_athrow without __name__>()> exception=RuntimeError('aclose(): asynchronous generator is already running')>
 RuntimeError: aclose(): asynchronous generator is already running
```

This pull request makes the library only use the features that are compatible with asyncio/trio and removes the above error.