### PR TITLE
stop using the word 'location' to represent the sizing/positioning p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ class KXDraggableBehavior:
             x=ctx.original_pos_win[0],
             y=ctx.original_pos_win[1],
         )
-        restore_widget_location(self, ctx.original_location)
+        restore_widget_state(self, ctx.original_state)
 ```
 
 If you don't need the animation, and want the draggable to go back instantly, overwrite the handler as follows:
@@ -128,7 +128,7 @@ If you don't need the animation, and want the draggable to go back instantly, ov
 ```python
 class MyDraggable(KXDraggableBehavior, Widget):
     def on_drag_fail(self, touch, ctx):
-        restore_widget_location(self, ctx.original_location)
+        restore_widget_state(self, ctx.original_state)
 ```
 
 Or if you want the draggable to not go back, and want it to stay the current position, overwrite the handler as follows:

--- a/README_jp.md
+++ b/README_jp.md
@@ -122,7 +122,7 @@ dragが失敗/成功/中止した時に何をするかは完全にあなたに�
 ```python
 class MyDraggable(KXDraggableBehavior, Widget):
     def on_drag_fail(self, touch, ctx):
-        restore_widget_location(self, ctx.original_location)
+        restore_widget_state(self, ctx.original_state)
 ```
 
 また何もせずにその場に残って欲しいなら以下のようにすれば良い。

--- a/examples/flutter_style_draggable.py
+++ b/examples/flutter_style_draggable.py
@@ -9,7 +9,7 @@ from kivy.lang import Builder
 from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.screenmanager import ScreenManager, NoTransition
 
-from kivy_garden.draggable import KXDroppableBehavior, KXDraggableBehavior, restore_widget_location
+from kivy_garden.draggable import KXDroppableBehavior, KXDraggableBehavior, restore_widget_state
 
 KV_CODE = '''
 <Cell>:
@@ -64,9 +64,9 @@ class FlutterStyleDraggable(KXDraggableBehavior, ScreenManager):
 
     def on_drag_start(self, touch, ctx):
         if self.has_screen('childWhenDragging'):
-            restore_widget_location(
+            restore_widget_state(
                 self.get_screen('childWhenDragging'),
-                ctx.original_location,
+                ctx.original_state,
             )
         return super().on_drag_start(touch, ctx)
 

--- a/src/kivy_garden/draggable/__init__.py
+++ b/src/kivy_garden/draggable/__init__.py
@@ -1,7 +1,9 @@
 __all__ = (
     'KXDraggableBehavior', 'KXDroppableBehavior', 'KXReorderableBehavior',
+    'save_widget_state', 'restore_widget_state',
     'save_widget_location', 'restore_widget_location', 'ongoing_drags',
 )
 
 from ._impl import KXDraggableBehavior, KXDroppableBehavior, KXReorderableBehavior, ongoing_drags
+from ._utils import save_widget_state, restore_widget_state
 from ._utils import save_widget_location, restore_widget_location

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -4,5 +4,6 @@ import pytest
 def test_flower():
     from kivy_garden.draggable import (
         KXDraggableBehavior, KXDroppableBehavior, KXReorderableBehavior,
+        restore_widget_state, save_widget_state,
         restore_widget_location, save_widget_location, ongoing_drags,
     )

--- a/tests/test_utils_restore_widget_location.py
+++ b/tests/test_utils_restore_widget_location.py
@@ -2,31 +2,31 @@ import pytest
 
 
 @pytest.fixture(scope='module')
-def location_factory():
+def state_factory():
     from copy import deepcopy
-    loc = {
+    state = {
         'x': 2, 'y': 2, 'width': 2, 'height': 2,
         'size_hint_x': 2, 'size_hint_y': 2,
         'pos_hint': {'center': [2, 2, ], },
         'size_hint_min_x': 2, 'size_hint_min_y': 2,
         'size_hint_max_x': 2, 'size_hint_max_y': 2,
     }
-    return lambda: deepcopy(loc)
+    return lambda: deepcopy(state)
 
 
 @pytest.mark.parametrize('ignore_parent', (True, False, ))
-def test_sizing_info(location_factory, ignore_parent):
+def test_sizing_info(state_factory, ignore_parent):
     from kivy.uix.widget import Widget
-    from kivy_garden.draggable import restore_widget_location
+    from kivy_garden.draggable import restore_widget_state
     w = Widget()
-    loc = location_factory()
-    restore_widget_location(w, loc, ignore_parent=ignore_parent)
-    loc['width'] = 0
-    loc['x'] = 0
-    loc['size_hint_x'] = 0
-    loc['pos_hint']['center'][0] = 0
-    loc['size_hint_min_x'] = 0
-    loc['size_hint_min_y'] = 0
+    state = state_factory()
+    restore_widget_state(w, state, ignore_parent=ignore_parent)
+    state['width'] = 0
+    state['x'] = 0
+    state['size_hint_x'] = 0
+    state['pos_hint']['center'][0] = 0
+    state['size_hint_min_x'] = 0
+    state['size_hint_min_y'] = 0
     assert w.size == [2, 2, ]
     assert w.pos == [2, 2, ]
     assert w.size_hint == [2, 2, ]
@@ -37,16 +37,16 @@ def test_sizing_info(location_factory, ignore_parent):
 
 @pytest.mark.parametrize('ignore_parent', (True, False, ))
 @pytest.mark.parametrize('has_parent', (True, False, ))
-def test_weak_parent_is_none(location_factory, ignore_parent, has_parent):
+def test_weak_parent_is_none(state_factory, ignore_parent, has_parent):
     from kivy.uix.widget import Widget
-    from kivy_garden.draggable import restore_widget_location
-    loc = location_factory()
-    loc['weak_parent'] = None
+    from kivy_garden.draggable import restore_widget_state
+    state = state_factory()
+    state['weak_parent'] = None
     w = Widget()
     if has_parent:
         parent = Widget()
         parent.add_widget(w)
-    restore_widget_location(w, loc, ignore_parent=ignore_parent)
+    restore_widget_state(w, state, ignore_parent=ignore_parent)
     if ignore_parent and has_parent:
         assert w.parent is parent
     else:
@@ -55,17 +55,16 @@ def test_weak_parent_is_none(location_factory, ignore_parent, has_parent):
 
 @pytest.mark.parametrize('ignore_parent', (True, False, ))
 @pytest.mark.parametrize('has_parent', (True, False, ))
-def test_weak_parent_not_in_the_keys(
-        location_factory, ignore_parent, has_parent):
+def test_weak_parent_not_in_the_keys(state_factory, ignore_parent, has_parent):
     from kivy.uix.widget import Widget
-    from kivy_garden.draggable import restore_widget_location
-    loc = location_factory()
-    assert 'weak_parent' not in loc
+    from kivy_garden.draggable import restore_widget_state
+    state = state_factory()
+    assert 'weak_parent' not in state
     w = Widget()
     if has_parent:
         parent = Widget()
         parent.add_widget(w)
-    restore_widget_location(w, loc, ignore_parent=ignore_parent)
+    restore_widget_state(w, state, ignore_parent=ignore_parent)
     if has_parent:
         assert w.parent is parent
     else:
@@ -74,22 +73,21 @@ def test_weak_parent_not_in_the_keys(
 
 @pytest.mark.parametrize('ignore_parent', (True, False, ))
 @pytest.mark.parametrize('has_parent', (True, False, ))
-def test_weak_parent_is_alive(
-        location_factory, ignore_parent, has_parent):
+def test_weak_parent_is_alive(state_factory, ignore_parent, has_parent):
     import weakref
     from kivy.uix.widget import Widget
-    from kivy_garden.draggable import restore_widget_location
+    from kivy_garden.draggable import restore_widget_state
     prev_parent = Widget()
-    loc = location_factory()
-    loc['weak_parent'] = weakref.ref(prev_parent)
-    loc['index'] = 0
+    state = state_factory()
+    state['weak_parent'] = weakref.ref(prev_parent)
+    state['index'] = 0
     w = Widget()
     if has_parent:
         parent = Widget()
         parent.add_widget(w)
         parent.add_widget(Widget())
         assert parent.children.index(w) == 1
-    restore_widget_location(w, loc, ignore_parent=ignore_parent)
+    restore_widget_state(w, state, ignore_parent=ignore_parent)
     if ignore_parent:
         if has_parent:
             assert w.parent is parent
@@ -103,17 +101,16 @@ def test_weak_parent_is_alive(
 
 @pytest.mark.parametrize('ignore_parent', (True, False, ))
 @pytest.mark.parametrize('has_parent', (True, False, ))
-def test_weak_parent_is_dead(
-        location_factory, ignore_parent, has_parent):
+def test_weak_parent_is_dead(state_factory, ignore_parent, has_parent):
     import gc
     import weakref
     from kivy.uix.widget import Widget
-    from kivy_garden.draggable import restore_widget_location
-    loc = location_factory()
-    loc['weak_parent'] = weakref.ref(Widget())
-    loc['index'] = 0
+    from kivy_garden.draggable import restore_widget_state
+    state = state_factory()
+    state['weak_parent'] = weakref.ref(Widget())
+    state['index'] = 0
     gc.collect()
-    assert loc['weak_parent']() is None
+    assert state['weak_parent']() is None
     w = Widget()
     if has_parent:
         parent = Widget()
@@ -121,10 +118,10 @@ def test_weak_parent_is_dead(
         parent.add_widget(Widget())
         assert parent.children.index(w) == 1
     if ignore_parent:
-        restore_widget_location(w, loc, ignore_parent=True)
+        restore_widget_state(w, state, ignore_parent=True)
     else:
         with pytest.raises(ReferenceError):
-            restore_widget_location(w, loc, ignore_parent=False)
+            restore_widget_state(w, state, ignore_parent=False)
     if has_parent:
         assert w.parent is parent
         assert parent.children.index(w) == 1

--- a/tests/test_utils_save_widget_location.py
+++ b/tests/test_utils_save_widget_location.py
@@ -4,9 +4,9 @@ import pytest
 @pytest.mark.parametrize('ignore_parent', (True, False, ))
 def test_no_parent(ignore_parent):
     from kivy.uix.widget import Widget
-    from kivy_garden.draggable import save_widget_location
+    from kivy_garden.draggable import save_widget_state
     w = Widget()
-    location = save_widget_location(w, ignore_parent=ignore_parent)
+    state = save_widget_state(w, ignore_parent=ignore_parent)
     expectation = {
         'x': 0, 'y': 0, 'width': 100, 'height': 100,
         'size_hint_x': 1, 'size_hint_y': 1, 'pos_hint': {},
@@ -16,19 +16,19 @@ def test_no_parent(ignore_parent):
     }
     if ignore_parent:
         del expectation['weak_parent']
-    assert location == expectation
+    assert state == expectation
 
 
 @pytest.mark.parametrize('ignore_parent', (True, False, ))
 def test_has_parent(ignore_parent):
     import weakref
     from kivy.uix.widget import Widget
-    from kivy_garden.draggable import save_widget_location
+    from kivy_garden.draggable import save_widget_state
     parent = Widget()
     w = Widget()
     parent.add_widget(w)
     parent.add_widget(Widget())
-    location = save_widget_location(w, ignore_parent=ignore_parent)
+    state = save_widget_state(w, ignore_parent=ignore_parent)
     expectation = {
         'x': 0, 'y': 0, 'width': 100, 'height': 100,
         'size_hint_x': 1, 'size_hint_y': 1, 'pos_hint': {},
@@ -39,15 +39,15 @@ def test_has_parent(ignore_parent):
     if ignore_parent:
         del expectation['weak_parent']
         del expectation['index']
-    assert location == expectation
+    assert state == expectation
 
 
 @pytest.mark.parametrize('ignore_parent', (True, False, ))
 def test_pos_hint_is_deepcopied(ignore_parent):
     from kivy.uix.widget import Widget
-    from kivy_garden.draggable import save_widget_location
+    from kivy_garden.draggable import save_widget_state
     w = Widget(pos_hint={'center': [.5, .5, ], })
-    location = save_widget_location(w, ignore_parent=ignore_parent)
-    location['pos_hint']['center'][0] = 0
-    location['pos_hint']['x'] = 0
+    state = save_widget_state(w, ignore_parent=ignore_parent)
+    state['pos_hint']['center'][0] = 0
+    state['pos_hint']['x'] = 0
     assert w.pos_hint == {'center': [.5, .5, ], }


### PR DESCRIPTION
…roperties of widget. Instead, use 'state'.

(This PR does not break the API as the previous names are still available).