### PR TITLE
Improve interoperability when Kivy runs in async mode

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     env:
       DISPLAY: ':99.0'
     steps:
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest flake8 kivy[base]==2.3.1 "asyncgui>=0.7,<0.8" "asynckivy>=0.7.1,<0.9"
+        python -m pip install pytest flake8 "kivy[base]>=2,<3" "asynckivy>=0.9,<0.10"
     - name: Install flower
       run: python -m pip install -e .
     - name: Lint with flake8

--- a/examples/customizing_animation.py
+++ b/examples/customizing_animation.py
@@ -63,10 +63,14 @@ class MyDraggable(KXDraggableBehavior, Label):
         self.parent.remove_widget(self)
         ctx.droppable.add_widget(self)
         abs_ = abs
-        async for p in ak.anim_with_ratio(base=.2):
-            if p > 1.:
-                break
-            self._scale = abs_(p * .8 - .4) + .6
+        async with ak.sleep_freq() as sleep:
+            et = 0.  # total elapsed time of the loop below
+            duration = .2
+            while True:
+                et += await sleep()
+                if et > duration:
+                    break
+                self._scale = abs_(et / duration * .8 - .4) + .6
 
 
 class Cell(KXDroppableBehavior, FloatLayout):

--- a/examples/customizing_animation_ver2.py
+++ b/examples/customizing_animation_ver2.py
@@ -46,11 +46,16 @@ class MyDraggable(KXDraggableBehavior, Label):
     async def on_drag_fail(self, touch, ctx):
         with ak.transform(self) as ig:
             ig.add(rotate := Rotate(origin=self.center))
-            async for p in ak.anim_with_ratio(base=.4):
-                if p > 1.:
-                    break
-                rotate.angle = p * 720.
-                self.opacity = 1. - p
+            async with ak.sleep_freq() as sleep:
+                et = 0.  # total elapsed time of the loop below
+                duration = .4
+                while True:
+                    et += await sleep()
+                    if et > duration:
+                        break
+                    p = et / duration
+                    rotate.angle = p * 720.
+                    self.opacity = 1. - p
             self.parent.remove_widget(self)
 
     async def on_drag_succeed(self, touch, ctx):
@@ -60,10 +65,14 @@ class MyDraggable(KXDraggableBehavior, Label):
         abs_ = abs
         with ak.transform(self) as ig:
             ig.add(scale := Scale(origin=self.center))
-            async for p in ak.anim_with_ratio(base=.2):
-                if p > 1.:
-                    break
-                scale.x = scale.y = abs_(p * .8 - .4) + .6
+            async with ak.sleep_freq() as sleep:
+                et = 0.  # total elapsed time of the loop below
+                duration = .2
+                while True:
+                    et += await sleep()
+                    if et > duration:
+                        break
+                    scale.x = scale.y = abs_(et / duration * .8 - .4) + .6
 
 
 class Cell(KXDroppableBehavior, FloatLayout):

--- a/examples/reacting_to_entering_and_leaving.py
+++ b/examples/reacting_to_entering_and_leaving.py
@@ -6,6 +6,7 @@ from kivy.uix.label import Label
 import asynckivy as ak
 
 from kivy_garden.draggable import KXDraggableBehavior, KXDroppableBehavior
+from kivy_garden.draggable._impl import _rest_of_touch_events
 
 KV_CODE = '''
 <MyDroppable>:
@@ -120,9 +121,11 @@ class ReactiveDroppableBehavior(KXDroppableBehavior):
 
         self.dispatch('on_drag_enter', touch, ctx, draggable)
         try:
-            async for __ in ak.rest_of_touch_events(self, touch):
-                if not collide_point(*touch.pos):
-                    return
+            async with _rest_of_touch_events(self, touch) as on_touch_move:
+                while True:
+                    await on_touch_move()
+                    if not collide_point(*touch.pos):
+                        return
         finally:
             self.dispatch('on_drag_leave', touch, ctx, draggable)
             del touch.ud[self.__ud_key]

--- a/poetry.lock
+++ b/poetry.lock
@@ -174,7 +174,7 @@ description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
     {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
@@ -541,7 +541,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
@@ -567,5 +567,5 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "0ce4d3f10667bee5e47da143185b6655d1b8438e6f531755152810ebbec9dbdb"
+python-versions = "^3.10"
+content-hash = "0312408f309ecd000d4ebaf096ef6e236bc18ba4cfb369062f832e9e3a1b3348"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers=[
     'License :: OSI Approved :: MIT License',
     'Intended Audience :: Developers',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
@@ -26,7 +25,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 asynckivy = ">=0.9,<0.10"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
In order for `asynckivy` to work perfectly alongside `asyncio` or `trio`, you must either (A) avoid using async generators or (B) explicitly close them while carefully propagate exceptions. I chose the option (A) here.